### PR TITLE
chore(ci): Adiciona cooldown do Dependabot e direciona PRs para develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 # Dependabot configuration
 # Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   # Root (Biome shared tooling)
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -14,13 +14,18 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
     groups:
       root-minor-patch:
         update-types: ["minor", "patch"]
-
   # Backend (Express + TypeScript)
   - package-ecosystem: "npm"
     directory: "/backend"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -29,13 +34,18 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
     groups:
       backend-minor-patch:
         update-types: ["minor", "patch"]
-
   # Frontend (React + Vite + TypeScript)
   - package-ecosystem: "npm"
     directory: "/frontend"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -44,13 +54,18 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
     groups:
       frontend-minor-patch:
         update-types: ["minor", "patch"]
-
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     commit-message:
@@ -58,3 +73,8 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30


### PR DESCRIPTION
## Endurecimento da cadeia de suprimentos

Adiciona bloco `cooldown` aos quatro blocos de update (npm root, npm backend, npm frontend, github-actions) e direciona os PRs de version update para a branch `develop` via `target-branch`.

### Cooldown
- `default-days`: 7 (piso para o que estiver fora das categorias semver)
- `semver-patch-days`: 7
- `semver-minor-days`: 14
- `semver-major-days`: 30

### Motivacao do cooldown
A maioria dos comprometimentos de cadeia de suprimentos (publicacao maliciosa, conta de mantenedor comprometida) e detectada e removida em horas a poucos dias. Aguardar a maturacao da versao antes de adotar reduz a exposicao a essa janela. Majors esperam mais (30 dias) por carregarem risco de breaking change e maior risco de supply-chain; patches esperam 7 dias para manter responsividade.

### target-branch
Os PRs de version update passam a mirar `develop` (integracao), alinhado ao Gitflow, em vez do default `main`. O proprio arquivo dependabot.yml permanece no `main`, pois o Dependabot le a configuracao sempre da branch default.

### Escopo
O cooldown aplica-se apenas a version updates. Security updates continuam imediatos. Observacao: o `target-branch` redireciona apenas version updates; security updates seguem o comportamento padrao.